### PR TITLE
update correct word

### DIFF
--- a/README.md
+++ b/README.md
@@ -4253,7 +4253,7 @@ Example:
 kid
 ```
 
-Ternary operators can be changed:
+Ternary operators can be chained:
 
 ```python
 >>> age = 15


### PR DESCRIPTION
correction to a wrong word from **changed** to **chained** in ternary operator section
Ternary operators can be **changed**, to **chained**:

```
>>> age = 15
>>> print('kid' if age < 13 else 'teenager' if age < 18 else 'adult')
teenager
```