### PR TITLE
Update grouping error in 12_Regular_Expressions.ipynb

### DIFF
--- a/jupyter_notebooks/12_Regular_Expressions.ipynb
+++ b/jupyter_notebooks/12_Regular_Expressions.ipynb
@@ -389,7 +389,7 @@
     "\n",
     "- When called on a regex with no groups, such as \\d-\\d\\d\\d-\\d\\d\\d\\d, the method findall() returns a list of ng matches, such as ['415-555-9999', '212-555-0000'].\n",
     "\n",
-    "- When called on a regex that has groups, such as (\\d\\d\\d)-d\\d)-(\\d\\ d\\d\\d), the method findall() returns a list of es of strings (one string for each group), such as [('415', ', '9999'), ('212', '555', '0000')].\n",
+    "- When called on a regex that has groups, such as (\\d\\d\\d)-(\\d\\d\\d\\d)-(\\d\\ d\\d\\d), the method findall() returns a list of es of strings (one string for each group), such as [('415', '555', '9999'), ('212', '555', '0000')].\n",
     "\n",
     "### Making Your Own Character Classes\n",
     "\n",


### PR DESCRIPTION
Fix error in .findall() grouping
- original grouping style did not compile
- changed return example to match updated grouping