### PR TITLE
Update 01_Python_Basics.md

### DIFF
--- a/markdown/01_Python_Basics.md
+++ b/markdown/01_Python_Basics.md
@@ -28,7 +28,7 @@ From **Highest** to **Lowest** precedence:
 | Operators | Operation        | Example         |
 | --------- | ---------------- | --------------- |
 | **        | Exponent         | `2 ** 3 = 8`    |
-| %         | Modulus/Remaider | `22 % 8 = 6`    |
+| %         | Modulus/Remainder | `22 % 8 = 6`    |
 | //        | Integer division | `22 // 8 = 2`   |
 | /         | Division         | `22 / 8 = 2.75` |
 | *         | Multiplication   | `3 * 3 = 9`     |


### PR DESCRIPTION
Spelling change from "Remaider" to "Remainder" for the modulus operator description