### PR TITLE
Fix str.format docs syntax error

### DIFF
--- a/blog_files/pysheet.md
+++ b/blog_files/pysheet.md
@@ -2338,7 +2338,7 @@ Python 3 introduced a new way to do string formatting that was later back-ported
 
 ```python
 >>> name = 'John'
->>> age = 20'
+>>> age = 20
 
 >>> "Hello I'm {}, my age is {}".format(name, age)
 "Hello I'm John, my age is 20"

--- a/markdown/11_String_Formatting.md
+++ b/markdown/11_String_Formatting.md
@@ -33,7 +33,7 @@ Python 3 introduced a new way to do string formatting that was later back-ported
 
 ```python
 name = 'John'
-age = 20'
+age = 20
 
 "Hello I'm {}, my age is {}".format(name, age)
 ```


### PR DESCRIPTION
I've used the github edit button to fix some small syntax errors in the docs for str.format.

Squashing the commits is probably preferred.