### PR TITLE
Fix typo in usage of dedent

### DIFF
--- a/markdown/10_Manipulating_Strings.md
+++ b/markdown/10_Manipulating_Strings.md
@@ -63,7 +63,7 @@ def my_function():
 
         Sincerely,
         Bob
-        ''')).strip()
+        '''))
 ```
 
 This generates the same string than before.


### PR DESCRIPTION
`.strip()` is not needed.  Besides code also doesn't work because print returns None.