### PR TITLE
Add examples for default split behavior

### DIFF
--- a/docs/cheatsheet/manipulating-strings.md
+++ b/docs/cheatsheet/manipulating-strings.md
@@ -221,7 +221,7 @@ The `join()` method takes all the items in an iterable, like a <router-link to="
 
 ### split()
 
-The `split()` method splits a `string` into a `list`. By default, it will use spaces to separate the items, but you can also set another character of choice:
+The `split()` method splits a `string` into a `list`. By default, it will use whitespace to separate the items, but you can also set another character of choice:
 
 ```python
 >>> 'My name is Simon'.split()
@@ -232,6 +232,12 @@ The `split()` method splits a `string` into a `list`. By default, it will use sp
 
 >>> 'My name is Simon'.split('m')
 # ['My na', 'e is Si', 'on']
+
+>>> ' My  name is  Simon'.split()
+# ['My', 'name', 'is', 'Simon']
+
+>>> ' My  name is  Simon'.split(' ')
+# ['', 'My', '', 'name', 'is', '', 'Simon']
 ```
 
 ## Justifying text with rjust(), ljust() and center()


### PR DESCRIPTION
Add examples for default split behavior, according to python docs: https://docs.python.org/3/library/stdtypes.html#str.split

If sep is given, consecutive delimiters are not grouped together and are deemed to delimit empty strings (for example, '1,,2'.split(',') returns ['1', '', '2']). The sep argument may consist of multiple characters (for example, '1<>2<>3'.split('<>') returns ['1', '2', '3']). Splitting an empty string with a specified separator returns [''].

If sep is not specified or is None, a different splitting algorithm is applied: runs of consecutive whitespace are regarded as a single separator, and the result will contain no empty strings at the start or end if the string has leading or trailing whitespace. Consequently, splitting an empty string or a string consisting of just whitespace with a None separator returns [].