### PR TITLE
update contributing guide

### DIFF
--- a/src/pages/contributing.md
+++ b/src/pages/contributing.md
@@ -27,14 +27,13 @@ This project and everyone who participates in it is governed by the [Contributor
 
         iwr https://get.pnpm.io/install.ps1 -useb | iex
 
-2.  Clone the project, change to the `next` branch and install the dependencies.
+2.  Fork the repo, copy the forked repo URL, clone the project and install the dependencies.
 
-        git clone https://github.com/wilfredinni/python-cheatsheet.git
+        git clone https://github.com/username/python-cheatsheet.git
         cd python-cheatsheet
-        git checkout next
         pnpm install
 
-3.  Create a new branch from `next`.
+3.  Create a new branch.
 
         git branch fix_bug
         git checkout fix_bug


### PR DESCRIPTION
We are unable to push the changes to repo directly. We got permission issues. 
That's why I have updated the contributing guide. We need to fork then do stuff on forked repo then push and pull request.

**Issues with old way:**
_remote: Permission to wilfredinni/python-cheatsheet.git denied to rawatdev.
fatal: unable to access 'https://github.com/wilfredinni/python-cheatsheet.git/': The requested URL returned error: 403_