### PR TITLE
Added default loop through dictionary keys

### DIFF
--- a/docs/cheatsheet/dictionaries.md
+++ b/docs/cheatsheet/dictionaries.md
@@ -55,6 +55,16 @@ The `keys()` method gets the **keys** of the dictionary:
 # color
 # age
 ```
+there is no need to use **.keys()** since by default you will loop through keys:
+```python
+>>> pet = {'color': 'red', 'age': 42}
+>>> for key in pet:
+...     print(key)
+...
+# color
+# age
+```
+
 
 ## items()
 


### PR DESCRIPTION
Hello, 

I came to this very useful cheatsheet and I noticed a detail in working with dict keys - where keys keyword does not need to be specified. I thought it is worth mentioning.