### PR TITLE
fix typo in docs/cheatsheet/sets.md

### DIFF
--- a/docs/cheatsheet/sets.md
+++ b/docs/cheatsheet/sets.md
@@ -110,7 +110,7 @@ Both methods will remove an element from the set, but `remove()` will raise a `k
 
 ## set union()
 
-`union()` or `|` will create a new set that with all the elements from the sets provided.
+`union()` or `|` will create a new set with all the elements from the sets provided.
 
 ```python
 >>> s1 = {1, 2, 3}


### PR DESCRIPTION
Remove `that` from the sentence: union() or | will create a new set ~that~ with all the elements from the sets provided.