### PR TITLE
Fix grammatical error within index.vue file

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -16,7 +16,7 @@ const cardLinks = [
   {
     path: '/contributing',
     name: 'Contribute',
-    description: `Get to know how easy is to contribute to the Python Cheatsheet.`,
+    description: `Get to know how easy it is to contribute to the Python Cheatsheet.`,
     icon: PluginIcon,
   },
   {


### PR DESCRIPTION
Fixed simple grammatical error within index.vue file. Changed "Get to know how easy is to contribute to the Python Cheatsheet" to  "Get to know how easy _**it**_ is to contribute to the Python Cheatsheet".