### PR TITLE
Remove Typo Line 330 in itertools

### DIFF
--- a/docs/modules/itertools-module.md
+++ b/docs/modules/itertools-module.md
@@ -327,8 +327,9 @@ Example:
 This function is very much like slices. This allows you to cut out a piece of an iterable.
 
 ```python
-itertools.islice(iterable, start, stop[, step])
+itertools.islice(iterable, start, stop, step])
 ```
+<!-- Removed the extra rectangular bracket (typo correction) -->
 
 Example:
 


### PR DESCRIPTION
Hi, 
There is a typo in the function argument of line 330 (in the file:- [itertools](https://github.com/wilfredinni/python-cheatsheet/blob/master/docs/modules/itertools-module.md), where a rectangular bracket has been typed before the third argument in the slicing function.
I have corrected it.
Best, 
Kartik