### PR TITLE
Moved string literal concatenation from basics to manipulating strings

### DIFF
--- a/docs/cheatsheet/manipulating-strings.md
+++ b/docs/cheatsheet/manipulating-strings.md
@@ -40,7 +40,7 @@ A raw string entirely ignores all escape characters and prints any backslash tha
 
 Raw strings are mostly used for <router-link to="/cheatsheet/regular-expressions">regular expression</router-link> definition.
 
-## Multiline Strings
+## Multiline strings
 
 ```python
 >>> print(
@@ -61,6 +61,18 @@ Raw strings are mostly used for <router-link to="/cheatsheet/regular-expressions
 # Sincerely,
 # Bob
 ```
+
+## String literal concatenation
+
+```python
+>>> print("[A-Za-z_]"       # letter or underscore
+...       "[A-Za-z0-9_]*"   # letter, digit or underscore
+... )
+
+# [A-Za-z_][A-Za-z0-9_]*
+```
+
+Does not work with variables or expressions.
 
 ## Indexing and Slicing strings
 


### PR DESCRIPTION
The basic or standard string concatenation is using "+" operator which works for both string literals and variables. String literal concatenation is more appropriate on manipulating strings section after multiline strings since this feature can be used to reduce the number of backslashes needed, to split long strings conveniently across long lines, or even to add comments to parts of strings. Reference; https://docs.python.org/3/reference/lexical_analysis.html#string-literal-concatenation , https://docs.python.org/3/tutorial/introduction.html#text , https://stackoverflow.com/questions/34174539/python-string-literal-concatenation