### PR TITLE
Moved string literal concatenation from basics to manipulating strings

### DIFF
--- a/docs/cheatsheet/basics.md
+++ b/docs/cheatsheet/basics.md
@@ -127,7 +127,7 @@ The _Walrus Operator_, or **Assignment Expression Operator** was firstly introdu
 String concatenation:
 
 ```python
->>> 'Alice' 'Bob'
+>>> 'Alice' + 'Bob'
 # 'AliceBob'
 ```
 


### PR DESCRIPTION
The basic or standard string concatenation is using "+" operator which works for both string literals and variables. String literal concatenation is more appropriate on manipulating strings section after multiline strings since this feature can be used to reduce the number of backslashes needed, to split long strings conveniently across long lines, or even to add comments to parts of strings. Reference; https://docs.python.org/3/reference/lexical_analysis.html#string-literal-concatenation , https://docs.python.org/3/tutorial/introduction.html#text , https://stackoverflow.com/questions/34174539/python-string-literal-concatenation