### PR TITLE
fix: Fixed ordering of ternary operator

### DIFF
--- a/docs/cheatsheet/control-flow.md
+++ b/docs/cheatsheet/control-flow.md
@@ -207,13 +207,13 @@ Ternary operators can be chained:
 >>> print('kid' if age < 13 else 'teen' if age < 18 else 'adult')
 
 >>> # is equivalent to this if statement:
->>> if age < 18:
-...     if age < 13:
-...         print('kid')
-...     else:
-...         print('teen')
+>>> if age < 13:
+...     print('kid')
 ... else:
-...     print('adult')
+...     if age < 18:
+...         print('teen')
+...     else:
+...         print('adult')
 ...
 # output: teen
 ```


### PR DESCRIPTION
Fixed ordering of ternary operator in the example when written out as if / else statements. The ternary operator is right-associative so it groups expressions from the right, and not left.