### PR TITLE
Fixed incorrect dictionary unpacking output

### DIFF
--- a/docs/cheatsheet/de/dictionaries.md
+++ b/docs/cheatsheet/de/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">

--- a/docs/cheatsheet/en/dictionaries.md
+++ b/docs/cheatsheet/en/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">

--- a/docs/cheatsheet/es/dictionaries.md
+++ b/docs/cheatsheet/es/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">

--- a/docs/cheatsheet/fr/dictionaries.md
+++ b/docs/cheatsheet/fr/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">

--- a/docs/cheatsheet/ja/dictionaries.md
+++ b/docs/cheatsheet/ja/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">

--- a/docs/cheatsheet/ko/dictionaries.md
+++ b/docs/cheatsheet/ko/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">

--- a/docs/cheatsheet/pt/dictionaries.md
+++ b/docs/cheatsheet/pt/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">

--- a/docs/cheatsheet/ru/dictionaries.md
+++ b/docs/cheatsheet/ru/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">

--- a/docs/cheatsheet/zh/dictionaries.md
+++ b/docs/cheatsheet/zh/dictionaries.md
@@ -378,7 +378,7 @@ dict_c
 ```
 
 ```output
-{'a': 1, 'b': 3, 'c': 4}
+{'b': 2, 'c': 4, 'a': 1}
 ```
 
 <BaseQuiz id="cheatsheet-dictionaries-2" correct="B">


### PR DESCRIPTION
Fixes #514

Updated the dictionary unpacking example output in all localized `dictionaries.md` files.

Later unpacked dictionaries override earlier keys in Python dictionary unpacking.
