### PR TITLE
feat: implement dark mode for scrollbars

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -25,9 +25,6 @@ const rootRepositoryRoutes = ['contributing', 'changelog']
           <div
             class="absolute bottom-0 right-0 top-16 hidden h-12 w-px bg-gradient-to-t from-slate-800 dark:block"
           />
-          <div
-            class="absolute bottom-0 right-0 top-28 hidden w-px bg-slate-800 dark:block"
-          />
           <div class="w-64 pr-8 xl:w-72 xl:pr-16">
             <the-sidebar-desktop />
           </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -5,6 +5,32 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  color-scheme: light;
+  --scrollbar-track: white;
+  --scrollbar-thumb: #cbd5e1;
+}
+
+html.dark {
+  color-scheme: dark;
+  --scrollbar-track: #111827;
+  --scrollbar-thumb: #475569;
+}
+
+html,
+body {
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+  border-radius: 999px;
+}
+
 /* 
  * Prose overrides - must be loaded after @tailwind utilities
  * This file contains styles that override Tailwind Typography defaults


### PR DESCRIPTION
# Before

<img width="1918" height="908" alt="image" src="https://github.com/user-attachments/assets/3e6722a7-884a-42b6-99fb-fa6fef8fecd6" />  

<br><br>
The scrollbars didn't change color when we toggled dark mode.

# After

<img width="1918" height="908" alt="image" src="https://github.com/user-attachments/assets/0c416d72-cc46-410a-8413-bf95b73e69bd" />  

<br><br>
Now the scrollbar correctly changes to dark mode when dark mode is toggled on.

# Implementation

Added custom scrollbar styles to `src/styles/index.css` file.

# Another small adjustment

Previously, there was an absolutely positioned separator in the sidebar that was only visible in dark mode:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/3d7ae070-9dff-4c2b-b84b-3519f53cab2a" />  

<br><br>
However, when we scroll down, it cuts off midway:

<img width="370" height="551" alt="image" src="https://github.com/user-attachments/assets/edaf5ae3-56f3-4060-b539-ebb2a688b25f" />  

<br><br>
Since it was completely invisible in light mode (see the screenshot below), I thought it would be better if I removed it instead of fixing it for consistency. It was only three lines of code, so not a big problem.

Light mode:

<img width="1662" height="882" alt="image" src="https://github.com/user-attachments/assets/522a56bd-b339-4d18-991c-bfe840735ddb" />  

<br><br>
Removed lines:

<img width="480" alt="image" src="https://github.com/user-attachments/assets/590d6a4d-f2bb-4f6f-b641-419c1c5835f5" />

## Verifications

- Verified that the mobile sidebar works correctly.
- Verified that light-mode also works correctly.
- Verified that other components like code blocks work correctly.